### PR TITLE
drop gulp-util (deprecated from 2014) and use plugin-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "glob": "^7.1.2",
-    "gulp-util": "^3.0.8",
+    "plugin-error": "^0.1.2",
     "purgecss": "^0.16.0",
     "through2": "^2.0.3"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import through from 'through2'
-import gulpUtil from 'gulp-util'
+import PluginError from 'plugin-error'
 import Purgecss from 'purgecss'
 import glob from 'glob'
 
@@ -26,7 +26,7 @@ const gulpPurgecss = options => {
         file.contents = new Buffer(result)
         callback(null, file)
       } catch (e) {
-        this.emit('error', new gulpUtil.PluginError(PLUGIN_NAME, e.message))
+        this.emit('error', new PluginError(PLUGIN_NAME, e.message))
       }
     }
     // stream
@@ -43,7 +43,7 @@ const gulpPurgecss = options => {
             file.contents = new Buffer(result)
             callback(null, file)
           } catch (e) {
-            this.emit('error', new gulpUtil.PluginError(PLUGIN_NAME, e.message))
+            this.emit('error', new PluginError(PLUGIN_NAME, e.message))
           }
         })
     }


### PR DESCRIPTION
## Proposed changes

Fix deprecation message
```
npm WARN deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
```

## Types of changes

What types of changes does your code introduce to gulp-purgecss?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
I just use official instruction from https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
  