### PR TITLE
Add `rejected` functionality, and update readme with Usage example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm install --save-dev gulp-purgecss
 
 ## Usage
 
+By default, `purgecss` outputs the source CSS _with unused selectors removed_.
+
 ```js
 const gulp = require('gulp')
 const purgecss = require('gulp-purgecss')
@@ -33,6 +35,26 @@ gulp.task('purgecss', () => {
     return gulp.src('src/**/*.css')
         .pipe(purgecss({
             content: ["src/**/*.html"]
+        }))
+        .pipe(gulp.dest('build/css'))
+})
+```
+
+By setting the `rejected` option, you can 'invert' the output to list _only the removed selectors_: 
+
+```js
+const gulp = require('gulp')
+const rename = require('gulp-rename')
+const purgecss = require('gulp-purgecss')
+
+gulp.task('purgecss', () => {
+    return gulp.src('src/**/*.css')
+        .pipe(rename({
+            suffix: '.rejected'
+        })
+        .pipe(purgecss({
+            content: ["src/**/*.html"],
+            rejected: true
         }))
         .pipe(gulp.dest('build/css'))
 })

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install --save-dev gulp-purgecss
 
 ## Usage
 
-By default, `purgecss` outputs the source CSS _with unused selectors removed_.
+By default, `purgecss` outputs the source CSS _with unused selectors removed_:
 
 ```js
 const gulp = require('gulp')
@@ -34,7 +34,7 @@ const purgecss = require('gulp-purgecss')
 gulp.task('purgecss', () => {
     return gulp.src('src/**/*.css')
         .pipe(purgecss({
-            content: ["src/**/*.html"]
+            content: ['src/**/*.html']
         }))
         .pipe(gulp.dest('build/css'))
 })
@@ -53,7 +53,7 @@ gulp.task('purgecss', () => {
             suffix: '.rejected'
         })
         .pipe(purgecss({
-            content: ["src/**/*.html"],
+            content: ['src/**/*.html'],
             rejected: true
         }))
         .pipe(gulp.dest('build/css'))

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const gulp = require('gulp')
 const rename = require('gulp-rename')
 const purgecss = require('gulp-purgecss')
 
-gulp.task('purgecss', () => {
+gulp.task('purgecss-rejected', () => {
     return gulp.src('src/**/*.css')
         .pipe(rename({
             suffix: '.rejected'

--- a/lib/gulpPurgecss.es.js
+++ b/lib/gulpPurgecss.es.js
@@ -27,7 +27,7 @@ var PLUGIN_NAME = 'gulp-purgecss';
 
 var getFiles = function getFiles(contentArray) {
   return contentArray.reduce(function (acc, content) {
-    return _toConsumableArray(acc).concat(_toConsumableArray(glob.sync(content)));
+    return [].concat(_toConsumableArray(acc), _toConsumableArray(glob.sync(content)));
   }, []);
 };
 
@@ -47,7 +47,8 @@ var gulpPurgecss = function gulpPurgecss(options) {
           }],
           stdin: true
         });
-        var result = new Purgecss(optionsGulp).purge()[0].css;
+        var purge = new Purgecss(optionsGulp).purge()[0];
+        var result = optionsGulp.rejected ? purge.rejected.join(' {}\n') + ' {}' : purge.css;
         file.contents = new Buffer(result);
         callback(null, file);
       } catch (e) {
@@ -66,7 +67,10 @@ var gulpPurgecss = function gulpPurgecss(options) {
             css: [css]
           });
 
-          var _result = new Purgecss(_optionsGulp).purge()[0].css;
+          var _purge = new Purgecss(_optionsGulp).purge()[0];
+
+          var _result = _optionsGulp.rejected ? _purge.rejected.join(' {}\n') + ' {}' : _purge.css;
+
           file.contents = new Buffer(_result);
           callback(null, file);
         } catch (e) {

--- a/lib/gulpPurgecss.js
+++ b/lib/gulpPurgecss.js
@@ -31,7 +31,7 @@ var PLUGIN_NAME = 'gulp-purgecss';
 
 var getFiles = function getFiles(contentArray) {
   return contentArray.reduce(function (acc, content) {
-    return _toConsumableArray(acc).concat(_toConsumableArray(glob.sync(content)));
+    return [].concat(_toConsumableArray(acc), _toConsumableArray(glob.sync(content)));
   }, []);
 };
 
@@ -51,7 +51,8 @@ var gulpPurgecss = function gulpPurgecss(options) {
           }],
           stdin: true
         });
-        var result = new Purgecss(optionsGulp).purge()[0].css;
+        var purge = new Purgecss(optionsGulp).purge()[0];
+        var result = optionsGulp.rejected ? purge.rejected.join(' {}\n') + ' {}' : purge.css;
         file.contents = new Buffer(result);
         callback(null, file);
       } catch (e) {
@@ -70,7 +71,10 @@ var gulpPurgecss = function gulpPurgecss(options) {
             css: [css]
           });
 
-          var _result = new Purgecss(_optionsGulp).purge()[0].css;
+          var _purge = new Purgecss(_optionsGulp).purge()[0];
+
+          var _result = _optionsGulp.rejected ? _purge.rejected.join(' {}\n') + ' {}' : _purge.css;
+
           file.contents = new Buffer(_result);
           callback(null, file);
         } catch (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const gulpPurgecss = options => {
           stdin: true
         })
         const purge = new Purgecss(optionsGulp).purge()[0]
-        const result = optionsGulp.rejected ? (purge.rejected.join(" {}\n")+" {}") : purge.css
+        const result = optionsGulp.rejected ? purge.rejected.join(' {}\n') + ' {}' : purge.css
         file.contents = new Buffer(result)
         callback(null, file)
       } catch (e) {
@@ -45,7 +45,7 @@ const gulpPurgecss = options => {
           try {
             const optionsGulp = Object.assign(options, { css: [css] })
             const purge = new Purgecss(optionsGulp).purge()[0]
-            const result = optionsGulp.rejected ? (purge.rejected.join(" {}\n")+" {}") : purge.css
+            const result = optionsGulp.rejected ? purge.rejected.join(' {}\n') + ' {}' : purge.css
             file.contents = new Buffer(result)
             callback(null, file)
           } catch (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,8 @@ const gulpPurgecss = options => {
           ],
           stdin: true
         })
-        const result = new Purgecss(optionsGulp).purge()[0].css
+        const purge = new Purgecss(optionsGulp).purge()[0]
+        const result = optionsGulp.rejected ? (purge.rejected.join(" {}\n")+" {}") : purge.css
         file.contents = new Buffer(result)
         callback(null, file)
       } catch (e) {
@@ -43,7 +44,8 @@ const gulpPurgecss = options => {
         .on('end', () => {
           try {
             const optionsGulp = Object.assign(options, { css: [css] })
-            const result = new Purgecss(optionsGulp).purge()[0].css
+            const purge = new Purgecss(optionsGulp).purge()[0]
+            const result = optionsGulp.rejected ? (purge.rejected.join(" {}\n")+" {}") : purge.css
             file.contents = new Buffer(result)
             callback(null, file)
           } catch (e) {


### PR DESCRIPTION
When its `rejected` [option](https://www.purgecss.com/configuration) is set, `purgecss` makes available the list of _removed_ selectors.

This PR defines `gulp-purgecss`'s response to that same option. When the `rejected` option is set, the plugin outputs a list of the removed selectors, rather than the default output.

It's extremely useful for the developer to sanity-check the list of rejected selectors, both to aid in identifying obsolete CSS that could be pruned from source files, and to discover any dynamically generated selector patterns that need to be whitelisted.

Importantly, this "inverted" output is still valid CSS: The list is formatted with empty declaration blocks for each selector in the list, so it will not cause errors when used as part of a Gulp process that still expects `gulp-purgecss` to output valid CSS (such as the new example provided in the README):

```js
const gulp = require('gulp')
const rename = require('gulp-rename')
const purgecss = require('gulp-purgecss')

gulp.task('purgecss-rejected', () => {
    return gulp.src('src/**/*.css')
        .pipe(rename({
            suffix: '.rejected'
        })
        .pipe(purgecss({
            content: ["src/**/*.html"],
            rejected: true
        }))
        .pipe(gulp.dest('build/css'))
})
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

- - -

(p.s. This feature was also [requested](https://github.com/FullHuman/postcss-purgecss/issues/16) for the `postcss-purgecss` plugin. I'll be happy to PR it there also, if you approve.)